### PR TITLE
feat: Country question tests

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -42,9 +42,10 @@ const App = () => {
   }
 
   const [privacyAllow, setPrivacyAllow] = useState(false)
-  const [privacy, setPrivacy] = useState(false)
+  const [modalText, setModalText] = useState('')
   const [show, setShow] = useState(false)
-  function onLinkOpen() {
+  function onLinkOpen(name) {
+    setModalText(forms.contact.textToShow[name])
     setShow(true)
   }
   const CustomCheckbox = (question, useForm) => {
@@ -102,7 +103,8 @@ const App = () => {
 
   const ModalCheckbox = () => {
     const [show, setShow] = useState(false)
-    function onLinkOpen() {
+    function onLinkOpen(name) {
+      console.log('tuputamadre')
       setShow(true)
     }
     return (
@@ -167,7 +169,7 @@ const App = () => {
         title='test'
         onClose={() => setShow(false)}
         show={show}
-        modalText='this a  modal example *markdown* **text** '
+        modalText={modalText}
       />
       <FormBuilder
         idForm={forms.contact.id}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2017,6 +2017,12 @@
         "picomatch": "^2.2.2"
       }
     },
+    "@sheerun/mutationobserver-shim": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
+      "integrity": "sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw==",
+      "dev": true
+    },
     "@storybook/addon-actions": {
       "version": "6.2.4",
       "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-6.2.4.tgz",
@@ -18014,6 +18020,15 @@
         "prop-types": "^15.6.0",
         "react-input-autosize": "^3.0.0",
         "react-transition-group": "^4.3.0"
+      }
+    },
+    "react-select-event": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-select-event/-/react-select-event-5.3.0.tgz",
+      "integrity": "sha512-Novkl7X9JJKmDV5LyYaKwl0vffWtqPrBa1vuI0v43P/f87mSA7JfdYxU93SFb99RssphVzBSIAbcnbX1w21QIQ==",
+      "dev": true,
+      "requires": {
+        "@testing-library/dom": ">=7"
       }
     },
     "react-sizeme": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@rollup/plugin-babel": "^5.2.2",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.1.0",
+    "@sheerun/mutationobserver-shim": "^0.3.3",
     "@storybook/addon-actions": "^6.1.15",
     "@storybook/addon-essentials": "^6.1.15",
     "@storybook/addon-links": "^6.1.15",
@@ -74,6 +75,7 @@
     "react-hook-form-input": "^1.1.10",
     "react-markdown": "^5.0.3",
     "react-phone-number-input": "^3.1.10",
+    "react-select-event": "^5.3.0",
     "rollup": "^2.36.2",
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "theme-ui": "^0.3.5"

--- a/src/Fields/Select/index.js
+++ b/src/Fields/Select/index.js
@@ -43,7 +43,7 @@ const Select = ({
   const customStyles = {}
 
   Object.keys(selectStyles).map((property) => {
-    if (theme.select && theme.select[property]) {
+    if (theme?.select && theme.select[property]) {
       selectStyles[property] = theme.select[property]
       customStyles[property] = (provided, state) => {
         if (state.isDisabled) {

--- a/src/Questions/Checkbox/__tests__/checkbox.test.js
+++ b/src/Questions/Checkbox/__tests__/checkbox.test.js
@@ -114,7 +114,7 @@ test('handles custom markdown link callback', () => {
       question={{
         ...question,
         label:
-          'I am over the age of 18, a United Kingdom resident and I have read and understood the [Terms and Conditions](#) of this promotion.'
+          'I am over the age of 18, a United Kingdom resident and I have read and understood the [Terms and Conditions](#T&C) of this promotion.'
       }}
       onLinkOpen={onLinkOpen}
       useForm={{
@@ -126,5 +126,5 @@ test('handles custom markdown link callback', () => {
   const markDownLink = getByRole('link')
   expect(markDownLink.href).toContain('#')
   fireEvent.click(markDownLink)
-  expect(onLinkOpen).toBeCalledWith(question.name)
+  expect(onLinkOpen).toBeCalledWith('T&C')
 })

--- a/src/Questions/Checkbox/index.js
+++ b/src/Questions/Checkbox/index.js
@@ -37,11 +37,11 @@ const QuestionCheckbox = ({
   const CustomComponent = ({ component }) => component(question, useForm)
 
   const MarkDownLink = ({ href, children }) =>
-    href === '#' ? (
+    href.startsWith('#') ? (
       <Link
         href={`${href}`}
         target='_self'
-        onClick={() => onLinkOpen(question.name)}
+        onClick={() => onLinkOpen(href.toString().substr(1))}
       >
         {children}
       </Link>
@@ -50,7 +50,6 @@ const QuestionCheckbox = ({
         {children}
       </Link>
     )
-
   return component ? (
     <CustomComponent component={component} />
   ) : (

--- a/src/Questions/Country/__tests__/country.test.js
+++ b/src/Questions/Country/__tests__/country.test.js
@@ -1,5 +1,11 @@
 import React from 'react'
-import { cleanup, getByText, screen, render } from '@testing-library/react'
+import {
+  cleanup,
+  getByText,
+  screen,
+  render,
+  fireEvent
+} from '@testing-library/react'
 import QuestionCountry from '../'
 import selectEvent from 'react-select-event'
 
@@ -13,6 +19,11 @@ const question = {
   type: 'country',
   label: 'This is the label of the country select',
   placeholder: 'Please select an option ^^',
+  customOrder: [
+    {
+      countryShortCode: 'GB'
+    }
+  ],
   errorMessages: {
     required: 'This field is required'
   }
@@ -28,9 +39,11 @@ const setup = () => {
 
   const countryComponent = renderComponent.getByTestId('question-country')
   const roleComponent = renderComponent.getByRole('textbox')
-  const labelComponent = renderComponent.getByText('Please select an option ^^')
+  const placeholderComponent = renderComponent.getByText(
+    'Please select an option ^^'
+  )
 
-  return { countryComponent, roleComponent, labelComponent }
+  return { countryComponent, roleComponent, placeholderComponent }
 }
 
 test('check the placeholder text', () => {
@@ -44,10 +57,19 @@ test('Country label', () => {
 })
 
 test('change value of select', async () => {
-  const { labelComponent } = setup()
-  await selectEvent.select(labelComponent, ['China'])
+  const { placeholderComponent } = setup()
+  await selectEvent.select(placeholderComponent, ['China'])
 
   expect(screen.getByText('China'))
+})
+
+test('check the custom order of the countries', async () => {
+  const { placeholderComponent } = setup()
+  await selectEvent.openMenu(placeholderComponent)
+  fireEvent.keyDown(placeholderComponent, { key: 'ArrowDown' })
+  fireEvent.keyDown(placeholderComponent, { key: 'Enter', code: 13 })
+
+  expect(screen.getByText('United Kingdom'))
 })
 
 test('show an error message', () => {

--- a/src/Questions/Country/__tests__/country.test.js
+++ b/src/Questions/Country/__tests__/country.test.js
@@ -1,0 +1,69 @@
+import React from 'react'
+import { cleanup, getByText, screen, render } from '@testing-library/react'
+import QuestionCountry from '../'
+import selectEvent from 'react-select-event'
+
+import MutationObserver from '@sheerun/mutationobserver-shim'
+window.MutationObserver = MutationObserver
+
+afterEach(cleanup)
+
+const question = {
+  name: 'country_of_residence',
+  type: 'country',
+  label: 'This is the label of the country select',
+  placeholder: 'Please select an option ^^',
+  errorMessages: {
+    required: 'This field is required'
+  }
+}
+
+const setup = () => {
+  const renderComponent = render(
+    <QuestionCountry
+      question={question}
+      useForm={{ errors: {}, register: () => {}, setValue: jest.fn() }}
+    />
+  )
+
+  const countryComponent = renderComponent.getByTestId('question-country')
+  const roleComponent = renderComponent.getByRole('textbox')
+  const labelComponent = renderComponent.getByText('Please select an option ^^')
+
+  return { countryComponent, roleComponent, labelComponent }
+}
+
+test('check the placeholder text', () => {
+  const { countryComponent } = setup()
+  getByText(countryComponent, 'Please select an option ^^')
+})
+
+test('Country label', () => {
+  const { countryComponent } = setup()
+  getByText(countryComponent, 'This is the label of the country select')
+})
+
+test('change value of select', async () => {
+  const { labelComponent } = setup()
+  await selectEvent.select(labelComponent, ['China'])
+
+  expect(screen.getByText('China'))
+})
+
+test('show an error message', () => {
+  const { getByText } = render(
+    <QuestionCountry
+      question={question}
+      useForm={{
+        errors: {
+          [question.name]: {
+            type: 'required'
+          }
+        },
+        register: () => {},
+        setValue: jest.fn()
+      }}
+    />
+  )
+  expect(getByText(question.errorMessages.required)).toBeTruthy()
+})

--- a/src/Questions/Country/__tests__/country.test.js
+++ b/src/Questions/Country/__tests__/country.test.js
@@ -38,12 +38,11 @@ const setup = () => {
   )
 
   const countryComponent = renderComponent.getByTestId('question-country')
-  const roleComponent = renderComponent.getByRole('textbox')
   const placeholderComponent = renderComponent.getByText(
     'Please select an option ^^'
   )
 
-  return { countryComponent, roleComponent, placeholderComponent }
+  return { countryComponent, placeholderComponent }
 }
 
 test('check the placeholder text', () => {

--- a/src/Questions/Country/country.stories.js
+++ b/src/Questions/Country/country.stories.js
@@ -1,0 +1,195 @@
+import React from 'react'
+import Country from './'
+
+export default {
+  title: 'Question/Country',
+  component: Country,
+  argTypes: {
+    name: {
+      type: { name: 'string', required: true },
+      description: 'Name of the country component',
+      table: {
+        type: { summary: 'string' }
+      }
+    },
+    isFullWidth: {
+      type: { name: 'boolean' },
+      description:
+        'Define if the field takes all the available width in the grid or not',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: false }
+      }
+    },
+    isMobile: {
+      type: { name: 'boolean' },
+      description:
+        'Define that the select should not take the default mobile styles of the SO',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: false }
+      }
+    },
+    label: {
+      type: { name: 'string' },
+      description:
+        'Text shown with the select. This text can be written in markdown style',
+      table: {
+        type: { summary: 'string' }
+      }
+    },
+    placeholder: {
+      type: { name: 'string' },
+      description: 'The text that will be shown as placeholder in the select',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: false }
+      }
+    },
+    customOrder: {
+      type: { name: 'object' },
+      description:
+        'An object or array of objects with the acronym(s) of the countries that you want to be shown the first in the country list',
+      table: {
+        type: { summary: 'json' }
+      }
+    },
+    customList: {
+      type: { name: 'object' },
+      description:
+        'An object or array of objects with the acronym(s) and the names of the countries that you want to be shown in the select.',
+      table: {
+        type: {
+          summary: 'json'
+        },
+        category: 'customList'
+      }
+    },
+    countryName: {
+      type: { name: 'string' },
+      description: 'The name of the country',
+      table: {
+        type: { summary: 'string' },
+        category: 'customList'
+      }
+    },
+    countryShortCode: {
+      type: { name: 'string' },
+      description: 'The code/shortcut for the country',
+      table: {
+        type: { summary: 'string' },
+        category: 'customList'
+      }
+    },
+    component: {
+      description: 'Customization of the country select',
+      table: {
+        type: { summary: 'func component' },
+        defaultValue: { summary: '() => {}' }
+      }
+    },
+    errorMessages: {
+      description: '',
+      table: {
+        type: { summary: 'json' },
+        category: 'errorMessages'
+      }
+    },
+    requiredError: {
+      name: 'required',
+      description:
+        'error message to display on submit if the checkbox is not checked',
+      table: {
+        type: { summary: 'string' },
+        category: 'errorMessages'
+      }
+    },
+    registerConfig: {
+      description: '',
+      table: {
+        type: { summary: 'json' },
+        category: 'registerConfig'
+      }
+    },
+    required: {
+      description: 'Define if the checkbox is required or not',
+      table: {
+        type: { summary: 'boolean' },
+        category: 'registerConfig',
+        defaultValue: { summary: false }
+      }
+    }
+  }
+}
+
+const question = {
+  name: 'country_of_residence',
+  label: 'This is the label of the country select',
+  placeholder: 'Please select an option ^^',
+  errorMessages: {
+    required: 'This field is required'
+  },
+  registerConfig: {
+    required: false
+  }
+}
+
+const customListCountries = [
+  { countryName: 'MyOwnCountry1', countryShortCode: 'MC1' },
+  { countryName: 'MyOwnCountry2', countryShortCode: 'MC2' },
+  { countryName: 'MyOwnCountry3', countryShortCode: 'MC3' },
+  { countryName: 'MyOwnCountry4', countryShortCode: 'MC4' }
+]
+
+const customListCountryQst = { ...question }
+customListCountryQst.customOrder = [
+  {
+    countryShortCode: 'GB'
+  }
+]
+
+const Template = (args) => (
+  <Country
+    question={args}
+    useForm={{ errors: {}, register: () => {}, setValue: () => {} }}
+  />
+)
+
+const errorTemplate = (args) => (
+  <Country
+    question={args}
+    useForm={{
+      errors: {
+        [question.name]: {
+          type: 'required'
+        }
+      },
+      register: () => {},
+      setValue: () => {}
+    }}
+  />
+)
+
+const customOrderTemplate = (args) => (
+  <Country
+    question={args}
+    useForm={{ errors: {}, register: () => {}, setValue: () => {} }}
+  />
+)
+
+const customListCountriesTemplate = (args) => (
+  <Country
+    question={args}
+    customList={customListCountries}
+    useForm={{ errors: {}, register: () => {}, setValue: () => {} }}
+  />
+)
+export const defaultCountry = Template.bind({})
+export const errorCountry = errorTemplate.bind({})
+export const customOrderCountries = customOrderTemplate.bind({})
+export const customListCountry = customListCountriesTemplate.bind({})
+
+defaultCountry.args = question
+errorCountry.args = question
+customOrderCountries.args = customListCountryQst
+customListCountry.args = question

--- a/src/Questions/Country/index.js
+++ b/src/Questions/Country/index.js
@@ -40,9 +40,10 @@ const priorizeCountriesOrder = (countries, order) => {
 
 const QuestionCountry = ({
   component,
-  isMobile = false,
+  isMobile = false, // TODO quitar esto ????? sera false by default no ?, definir type en la docu?
   question,
   useForm,
+  customList,
   ...props
 }) => {
   const { errors, register, setValue } = useForm
@@ -80,7 +81,7 @@ const QuestionCountry = ({
 
   const options = getCountriesOptions(
     question.placeholder,
-    CountryAndRegionsData
+    customList || CountryAndRegionsData
   )
 
   return component ? (
@@ -112,7 +113,10 @@ const QuestionCountry = ({
         {...props}
       >
         {renderCountryOptions(
-          getCountriesOptions(question.placeholder, CountryAndRegionsData)
+          getCountriesOptions(
+            question.placeholder,
+            customList || CountryAndRegionsData
+          )
         )}
       </Select>
       {errors[question.name] &&

--- a/src/Questions/Country/index.js
+++ b/src/Questions/Country/index.js
@@ -87,6 +87,7 @@ const QuestionCountry = ({
     <CustomComponent component={component} />
   ) : (
     <div
+      data-testid='question-country'
       sx={
         question.isFullWidth
           ? {


### PR DESCRIPTION
feat: added test for the country question.

tests for: 
- The place holder 
- The label existence 
-  The select component can change its value and select another option 
-  Check that the custom order countries work, sending GB and selecting the 1º item to check that is UK a203518
- Error message is displayed 

No se que te parece si ves algún test interesante que pueda darle, la verdad que estos test fueron jodidos porque el react select hace cosas rarillas no es un select normal y tuve que estar jugando un ratillo para que me hiciera caso 😅 

storybook: c0494bc

- Default country
- Country with show error message 
- Country with UK as the first option displayed
- Country with a custom list of countries: 
   - This is a new possibility that i have added based in the problem that we had with china that we needed a custom list, 
      now  QuestionCountry accepts a list made by the user and it used instead of the default list 


