### PR TITLE
Question date

### DIFF
--- a/src/Fields/Date/index.js
+++ b/src/Fields/Date/index.js
@@ -3,8 +3,12 @@ import { jsx } from 'theme-ui'
 
 import React from 'react'
 import { RHFInput } from 'react-hook-form-input'
-import ReactDatePicker from 'react-datepicker'
+import ReactDatePicker, { registerLocale } from 'react-datepicker'
 import { differenceInYears, subYears } from 'date-fns'
+import de from 'date-fns/locale/de'
+import fr from 'date-fns/locale/fr'
+import es from 'date-fns/locale/es'
+import en from 'date-fns/locale//en-GB'
 
 const DatePicker = ({
   register,
@@ -13,14 +17,21 @@ const DatePicker = ({
   registerConfig,
   placeholder,
   isMobile,
+  language,
   dateFormat,
-  isBirthDate,
-  minAge,
+  minAge = 0,
   openToDate = '',
   ...props
 }) => {
   const [date, setDate] = React.useState(new Date())
   const pickerRef = React.useRef(null)
+  const mapLanguagues = { de, fr, es, en }
+  const datepickerLanguage =
+    language && mapLanguagues[language.toLowerCase()]
+      ? mapLanguagues[language.toLowerCase()]
+      : mapLanguagues.en
+
+  registerLocale(datepickerLanguage.code, datepickerLanguage)
   React.useEffect(() => {
     if (isMobile && pickerRef.current !== null) {
       pickerRef.current.input.readOnly = true
@@ -28,11 +39,11 @@ const DatePicker = ({
   }, [isMobile, pickerRef])
 
   const isOver18 = (date) => {
-    return differenceInYears(new Date(), date) >= (minAge || 18)
+    return differenceInYears(new Date(), date) >= minAge
   }
 
   const getInitialDate = () => {
-    return subYears(new Date(), minAge || 18)
+    return subYears(new Date(), minAge)
   }
 
   const convertLocalToUTCDate = (date) => {
@@ -46,26 +57,19 @@ const DatePicker = ({
     return date
   }
 
-  const [day, month, year] = openToDate.split('-')
-
   return (
     <RHFInput
       as={
         <ReactDatePicker
           ref={pickerRef}
           portalId='root-portal'
+          locale={datepickerLanguage.code}
           withPortal={isMobile}
           placeholderText={placeholder}
           dateFormat={dateFormat || 'dd/MM/yyyy'}
           showYearDropdown
           dropdownMode={isMobile ? 'select' : 'scroll'}
-          openToDate={
-            openToDate.split('-').length === 3
-              ? new Date(year, month - 1, day)
-              : isBirthDate
-              ? getInitialDate()
-              : date || new Date()
-          }
+          openToDate={openToDate ? new Date(openToDate) : getInitialDate()}
           disabledKeyboardNavigation
           {...props}
         />
@@ -73,7 +77,7 @@ const DatePicker = ({
       rules={{
         ...registerConfig,
         validate: {
-          u18: isBirthDate ? isOver18 : () => true
+          underAge: minAge ? isOver18 : () => true
         }
       }}
       name={name}

--- a/src/Questions/Date/__tests__/date.test.js
+++ b/src/Questions/Date/__tests__/date.test.js
@@ -1,0 +1,308 @@
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import QuestionDate from '../'
+
+const question = {
+  name: 'dob',
+  type: 'date',
+  label: 'Date of birth',
+  placeholder: 'dd/mm/yyyy',
+  openToDate: '1-1-2000',
+  errorMessages: {
+    required: 'This field is required',
+    underAge: 'You must be 18 years old or above'
+  },
+  registerConfig: {
+    required: true
+  }
+}
+
+Object.defineProperty(window, 'getComputedStyle', {
+  value: () => ({
+    marginLeft: 0,
+    borderLeftWidth: 0
+  })
+})
+
+if (global.document) {
+  document.createRange = () => ({
+    setStart: () => {},
+    setEnd: () => {},
+    commonAncestorContainer: {
+      nodeName: 'BODY',
+      ownerDocument: document
+    }
+  })
+}
+
+const monthNames = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December'
+]
+
+test('placeholder is displayed', () => {
+  const { getByPlaceholderText } = render(
+    <QuestionDate
+      question={question}
+      useForm={{ errors: {}, register: () => {} }}
+    />
+  )
+
+  expect(getByPlaceholderText('dd/mm/yyyy'))
+})
+
+test('required error is displayed', () => {
+  const { getByText } = render(
+    <QuestionDate
+      question={question}
+      useForm={{
+        errors: {
+          [question.name]: {
+            type: 'required'
+          }
+        },
+        register: () => {}
+      }}
+    />
+  )
+
+  expect(getByText('This field is required'))
+})
+
+test('under-age error error is displayed', () => {
+  const { getByText } = render(
+    <QuestionDate
+      question={question}
+      useForm={{
+        errors: {
+          [question.name]: {
+            type: 'underAge'
+          }
+        },
+        register: () => {}
+      }}
+    />
+  )
+
+  expect(getByText('You must be 18 years old or above'))
+})
+
+test('calendar is opened in the right date', () => {
+  const { getByPlaceholderText } = render(
+    <QuestionDate
+      question={question}
+      useForm={{
+        errors: {},
+        register: () => {}
+      }}
+    />
+  )
+  const calendar = getByPlaceholderText('dd/mm/yyyy')
+
+  fireEvent.click(calendar)
+
+  expect(screen.getByText('January 2000'))
+})
+
+test('calendar is opened minAge years ago', () => {
+  const question = {
+    name: 'dob',
+    type: 'date',
+    label: 'Date of birth',
+    placeholder: 'dd/mm/yyyy',
+    minAge: 23,
+    errorMessages: {
+      required: 'This field is required'
+    },
+    registerConfig: {
+      required: true
+    }
+  }
+  const { getByPlaceholderText } = render(
+    <QuestionDate
+      question={question}
+      useForm={{
+        errors: {},
+        register: () => {}
+      }}
+    />
+  )
+
+  const datepicker = getByPlaceholderText('dd/mm/yyyy')
+
+  fireEvent.click(datepicker)
+  const date = new Date()
+
+  const dayYear =
+    monthNames[date.getMonth().toString()] +
+    ' ' +
+    (date.getFullYear() - question.minAge)
+
+  expect(screen.getByText(dayYear, { exact: false })).toBeTruthy()
+})
+
+test('calendar is opened in new Date', () => {
+  const question = {
+    name: 'dob',
+    type: 'date',
+    label: 'Date of birth',
+    placeholder: 'dd/mm/yyyy',
+    errorMessages: {
+      required: 'This field is required'
+    },
+    registerConfig: {
+      required: true
+    }
+  }
+  const { getByPlaceholderText } = render(
+    <QuestionDate
+      question={question}
+      useForm={{
+        errors: {},
+        register: () => {}
+      }}
+    />
+  )
+
+  const datepicker = getByPlaceholderText('dd/mm/yyyy')
+
+  fireEvent.click(datepicker)
+  const date = new Date()
+
+  const dayYear =
+    monthNames[date.getMonth().toString()] + ' ' + date.getFullYear()
+
+  expect(screen.getByText(dayYear, { exact: false })).toBeTruthy()
+})
+
+test('dateformat is applied', () => {
+  const question = {
+    name: 'dob',
+    type: 'date',
+    label: 'Date of birth',
+    placeholder: 'dd/mm/yyyy',
+    dateFormat: 'dd-MM-yyyy',
+    errorMessages: {
+      required: 'This field is required'
+    },
+    registerConfig: {
+      required: true
+    }
+  }
+
+  const { getByPlaceholderText } = render(
+    <QuestionDate
+      question={question}
+      useForm={{
+        errors: {},
+        register: () => {},
+        setValue: jest.fn()
+      }}
+    />
+  )
+  const datepicker = getByPlaceholderText('dd/mm/yyyy')
+  fireEvent.change(datepicker, { target: { value: '11/11/2011' } })
+  fireEvent.click(datepicker)
+  fireEvent.keyDown(datepicker, { key: 'Enter', code: 13 })
+  expect(datepicker.value).toBe('11-11-2011')
+})
+
+test('default dateformat is applied', () => {
+  const { getByPlaceholderText } = render(
+    <QuestionDate
+      question={question}
+      useForm={{
+        errors: {},
+        register: () => {},
+        setValue: jest.fn()
+      }}
+    />
+  )
+  const datepicker = getByPlaceholderText('dd/mm/yyyy')
+  fireEvent.change(datepicker, { target: { value: '11-11-2011' } })
+  fireEvent.click(datepicker)
+  fireEvent.keyDown(datepicker, { key: 'Enter', code: 13 })
+  expect(datepicker.value).toBe('11/11/2011')
+})
+
+test('calendar is in spanish', () => {
+  const { getByPlaceholderText } = render(
+    <QuestionDate
+      question={question}
+      language='es'
+      useForm={{
+        errors: {},
+        register: () => {}
+      }}
+    />
+  )
+  const calendar = getByPlaceholderText('dd/mm/yyyy')
+
+  fireEvent.click(calendar)
+
+  expect(screen.getByText('Enero 2000', { exact: false })).toBeTruthy()
+})
+
+test('calendar is in french', () => {
+  const { getByPlaceholderText } = render(
+    <QuestionDate
+      question={question}
+      language='fr'
+      useForm={{
+        errors: {},
+        register: () => {}
+      }}
+    />
+  )
+  const calendar = getByPlaceholderText('dd/mm/yyyy')
+
+  fireEvent.click(calendar)
+
+  expect(screen.getByText('janvier 2000', { exact: false })).toBeTruthy()
+})
+
+test('calendar is in french', () => {
+  const { getByPlaceholderText } = render(
+    <QuestionDate
+      question={question}
+      language='de'
+      useForm={{
+        errors: {},
+        register: () => {}
+      }}
+    />
+  )
+  const calendar = getByPlaceholderText('dd/mm/yyyy')
+
+  fireEvent.click(calendar)
+
+  expect(screen.getByText('januar 2000', { exact: false })).toBeTruthy()
+})
+
+test('calendar sending no-valid language', () => {
+  const { getByPlaceholderText } = render(
+    <QuestionDate
+      question={question}
+      language='qwerty'
+      useForm={{
+        errors: {},
+        register: () => {}
+      }}
+    />
+  )
+  const calendar = getByPlaceholderText('dd/mm/yyyy')
+
+  fireEvent.click(calendar)
+
+  expect(screen.getByText('january 2000', { exact: false })).toBeTruthy()
+})

--- a/src/Questions/Date/date.stories.js
+++ b/src/Questions/Date/date.stories.js
@@ -1,0 +1,203 @@
+import React from 'react'
+import Date from './'
+import 'react-datepicker/dist/react-datepicker.css'
+
+export default {
+  title: 'Question/Date',
+  component: Date,
+  argTypes: {
+    name: {
+      type: { name: 'string', required: true },
+      description: 'Name of the Date component',
+      table: {
+        type: { summary: 'string' }
+      }
+    },
+    label: {
+      type: { name: 'string' },
+      description: 'Text shown with the input.',
+      table: {
+        type: { summary: 'string' }
+      }
+    },
+    placeholder: {
+      type: { name: 'string' },
+      description:
+        'The text that will be shown as placeholder in the date input',
+      table: {
+        type: { summary: 'string' }
+      }
+    },
+    component: {
+      description:
+        'Custom component that will replace  the default date component',
+      table: {
+        type: { summary: 'func component' },
+        defaultValue: { summary: '() => {}' }
+      }
+    },
+    minAge: {
+      description:
+        'the minimun age that the user should have, the calendar will be opened in that date',
+      table: {
+        type: { summary: 'int' }
+      }
+    },
+    dateFormat: {
+      description: 'the format that we want in the dates',
+      table: {
+        type: { summary: 'string' }
+      }
+    },
+    errorMessages: {
+      description: '',
+      table: {
+        type: { summary: 'json' },
+        category: 'errorMessages'
+      }
+    },
+    requiredError: {
+      name: 'required',
+      description:
+        'error message to display on submit if a date is not selected',
+      table: {
+        type: { summary: 'string' },
+        category: 'errorMessages'
+      }
+    },
+    underAge: {
+      description:
+        'error message to display is the date selected is under minAge attribute',
+      table: {
+        type: { summary: 'string' },
+        category: 'errorMessages'
+      }
+    },
+    registerConfig: {
+      description: '',
+      table: {
+        type: { summary: 'json' },
+        category: 'registerConfig'
+      }
+    },
+    required: {
+      description: 'Define if the date is required or not',
+      table: {
+        type: { summary: 'boolean' },
+        category: 'registerConfig',
+        defaultValue: { summary: false }
+      }
+    }
+  }
+}
+
+const question = {
+  name: 'dob',
+  type: 'date',
+  label: 'Date of birth',
+  errorMessages: {
+    required: 'This field is required'
+  },
+  registerConfig: {
+    required: true
+  }
+}
+
+const openToQuestion = { ...question }
+const openOnBirthDateQuestion = { ...question }
+const errorUnderAgeQuestion = JSON.parse(JSON.stringify(question))
+const placeholderQuestion = { ...question }
+const formatQuestion = { ...question }
+
+openToQuestion.openToDate = '1-1-2000'
+
+openOnBirthDateQuestion.minAge = 18
+
+errorUnderAgeQuestion.errorMessages.underAge =
+  'you dont have the required minimum age'
+
+placeholderQuestion.placeholder = 'date place holder'
+
+formatQuestion.dateFormat = 'dd-MM-yyyy'
+formatQuestion.placeholder = 'dd-mm-yyyy'
+
+const Template = (args) => (
+  <Date
+    question={args}
+    useForm={{ errors: {}, register: () => {}, setValue: () => {} }}
+  />
+)
+
+const openToDateTemplate = (args) => (
+  <Date
+    question={args}
+    useForm={{ errors: {}, register: () => {}, setValue: () => {} }}
+  />
+)
+
+const openOnBirthdateTemplate = (args) => (
+  <Date
+    question={args}
+    useForm={{ errors: {}, register: () => {}, setValue: () => {} }}
+  />
+)
+
+const requiredErrorTemplate = (args) => (
+  <Date
+    question={args}
+    useForm={{
+      errors: {
+        [question.name]: {
+          type: 'required'
+        }
+      },
+      register: () => {},
+      setValue: () => {}
+    }}
+  />
+)
+
+const underAgeErrorTemplate = (args) => (
+  <Date
+    question={args}
+    useForm={{
+      errors: {
+        [question.name]: {
+          type: 'underAge'
+        }
+      },
+      register: () => {},
+      setValue: () => {}
+    }}
+  />
+)
+
+const placerholderTemplate = (args) => (
+  <Date
+    question={args}
+    useForm={{ errors: {}, register: () => {}, setValue: () => {} }}
+  />
+)
+
+const dateFormatTemplate = (args) => (
+  <Date
+    question={args}
+    useForm={{ errors: {}, register: () => {}, setValue: () => {} }}
+  />
+)
+
+export const defaultDate = Template.bind()
+export const placeholderDate = placerholderTemplate.bind()
+export const openToDate = openToDateTemplate.bind()
+export const openWithBirthDate = openOnBirthdateTemplate.bind()
+export const requiredErrorDate = requiredErrorTemplate.bind()
+export const underAgeErrorDate = underAgeErrorTemplate.bind()
+export const formatDate = dateFormatTemplate.bind()
+
+defaultDate.args = question
+openToDate.args = openToQuestion
+openWithBirthDate.args = openOnBirthDateQuestion
+requiredErrorDate.args = question
+underAgeErrorDate.args = errorUnderAgeQuestion
+placeholderDate.args = placeholderQuestion
+formatDate.args = formatQuestion

--- a/src/Questions/Date/index.js
+++ b/src/Questions/Date/index.js
@@ -10,8 +10,8 @@ const QuestionDate = ({
   component,
   useForm,
   question,
-  isBirthDate,
   isMobile,
+  language,
   ...props
 }) => {
   const { errors, register, setValue } = useForm
@@ -32,13 +32,13 @@ const QuestionDate = ({
           sx={{ width: '100%', variant: 'forms.input' }}
           placeholder={question.placeholder}
           key={question.name}
+          language={language}
           name={question.name}
           register={register}
           registerConfig={question.registerConfig}
           setValue={setValue}
           isMobile={isMobile}
           dateFormat={question.dateFormat}
-          isBirthDate={isBirthDate}
           minAge={question.minAge}
           openToDate={question.openToDate}
           selected={question.openToDate}
@@ -49,9 +49,9 @@ const QuestionDate = ({
             message={question.errorMessages && question.errorMessages.required}
           />
         )}
-        {errors[question.name] && errors[question.name].type === 'u18' && (
+        {errors[question.name] && errors[question.name].type === 'underAge' && (
           <ErrorMessage
-            message={question.errorMessages && question.errorMessages.u18}
+            message={question.errorMessages && question.errorMessages.underAge}
           />
         )}
       </div>

--- a/src/builder.js
+++ b/src/builder.js
@@ -103,7 +103,7 @@ const FormBuilder = ({
         <QuestionDate
           useForm={useFormObj}
           question={question}
-          isBirthDate={question.isBirthDate || false}
+          language={props.language}
           isMobile={isMobile}
           component={props.customDate}
         />

--- a/src/stories/Date.stories.js
+++ b/src/stories/Date.stories.js
@@ -28,6 +28,5 @@ export const Primary = Template.bind({})
 Primary.args = {
   placeholder: '',
   dateFormat: 'dd-MM-yyyy',
-  isMobile: false,
-  isBirthDate: false
+  isMobile: false
 }


### PR DESCRIPTION
**Refactor question date** :  6e6cdb1

- Removing the logic related with the openToDate, now if you want to open in a day you can send the date as string with any format in the attribute `openToDate` || can be opened with `minAge` subtracting today - `minAge`

- renaming u18 --> `underAge` (name has more sense now due to the new logic)

- Now date can be shown in (spanish, german, english or french) depending on the attribute `language` sent like in `countryQuestion` same logic ( it has sense that if we want a language everything should be in that language)

**Storybooks**:  02fcc18

- default datepicker
- datepicker opened in the date asked
- opened minAge 18years ago
- required error 
- underAge error 
- changing the placeholder
- fomatedDate

**Testing**:  6192775

- placeholder is displayed
- required error & minAge error
- calendar is opened in the sent date
- calendar is opened in MinAge years ago
- calendar is opened today
- dateFormat && default format  selected for dates are applied although user try to use another one
- calendar in es,fr,de,en and check non existed language is sent --> en is used
